### PR TITLE
bump min python version to match obsws-python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "OBS CLI"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = ["obs", "obs-studio"]
 license = {file = "LICENSE"}
 classifiers = [


### PR DESCRIPTION
Hi, great job with this package!

I noticed in pyproject.toml requires-python is set to 3.8 but obsws-python requires >=3.9. This causes the following issue when installing into a venv:

```
Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and obsws-python>=1.4.0 depends on Python>=3.9, we can conclude that obsws-python>=1.4.0 cannot be used.
And because we know from (1) that obsws-python<1.4.0 cannot be used, we can conclude that all versions of obsws-python cannot be used.
And because your project depends on obsws-python, we can conclude that your project's requirements are unsatisfiable.
```

Bumping requires-python to 3.9 fixes this issue.

Thanks.