### PR TITLE
Add input `is-muted` property

### DIFF
--- a/obs_cli.py
+++ b/obs_cli.py
@@ -99,9 +99,10 @@ def parse_args():
             "mute",
             "unmute",
             "toggle-mute",
+            "is-muted",
         ],
         default="show",
-        help="list/show/get/set/mute/unmute/toggle-mute",
+        help="list/show/get/set/mute/unmute/toggle-mute/is-muted",
     )
     input_parser.add_argument("INPUT", nargs="?", help="Input name")
     input_parser.add_argument("PROPERTY", nargs="?", help="Property name")
@@ -557,6 +558,10 @@ def main():
             elif args.action == "toggle-mute":
                 res = toggle_mute_input(cl, args.INPUT)
                 LOGGER.debug(res)
+
+            elif args.action == "is-muted":
+                res = get_mute_state(cl, args.INPUT)
+                print("enabled" if res else "disabled")
 
         elif cmd == "filter":
             if args.action == "list":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+markdown-it-py==4.0.0
+mdurl==0.1.2
+obsws-python==1.8.0
+Pygments==2.19.2
+rich==14.1.0
+tomli==2.2.1
+websocket-client==1.8.0


### PR DESCRIPTION
This exposes `get_mute_state` to the CLI so users can query whether an input is muted. 

```
$ obs_cli input is-muted Mic/Aux
enabled
$ obs_cli input toggle-mute Mic/Aux
$ obs_cli input is-muted Mic/Aux
disabled
```